### PR TITLE
iOS: Fixes rendering in release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create shapes content views from shared code for your mobile apps!
 
 ### iOS Extra setup
 
-Add Renderers.Init(); to the AppDelegate like so:
+Add ShapeRenderer.Init(); to the AppDelegate like so:
 
 ```csharp
 using XFShapeView.iOS;
@@ -21,7 +21,7 @@ public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 {
     global::Xamarin.Forms.Forms.Init();
 
-    Renderers.Init();
+    ShapeRenderer.Init();
 
     LoadApplication(new App());
 

--- a/sample/XFShapeViewSample/XFShapeViewSample.iOS/AppDelegate.cs
+++ b/sample/XFShapeViewSample/XFShapeViewSample.iOS/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using Foundation;
@@ -25,7 +26,7 @@ namespace XFShapeViewSample.iOS
         {
             global::Xamarin.Forms.Forms.Init();
 
-            Renderers.Init();
+			ShapeRenderer.Init();
 
             LoadApplication(new App());
 

--- a/src/XFShapeView.iOS/Renderers.cs
+++ b/src/XFShapeView.iOS/Renderers.cs
@@ -1,9 +1,0 @@
-﻿namespace XFShapeView.iOS
-{
-    public class Renderers
-    {
-        public static void Init()
-        {
-        }
-    }
-}

--- a/src/XFShapeView.iOS/ShapeRenderer.cs
+++ b/src/XFShapeView.iOS/ShapeRenderer.cs
@@ -43,6 +43,11 @@ namespace XFShapeView.iOS
             base.ContentMode = UIViewContentMode.Redraw;
         }
 
+		public static void Init()
+		{
+			var r = new ShapeRenderer();
+		}
+
         public override void Draw(CGRect rect)
         {
             base.Draw(rect);

--- a/src/XFShapeView.iOS/XFShapeView.iOS.csproj
+++ b/src/XFShapeView.iOS/XFShapeView.iOS.csproj
@@ -60,7 +60,6 @@
   <ItemGroup>
     <Compile Include="PointExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Renderers.cs" />
     <Compile Include="ShapeRenderer.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Removes the empty Renderer class and Init method and creates a new Init method in ShapeRenderer that instantiates the Renderer so the linker preserves it in release modes. 