### PR TITLE
Adding a new bindable property : RadiusPosition

### DIFF
--- a/sample/XFShapeViewSample/XFShapeViewSample.Droid/XFShapeViewSample.Droid.csproj
+++ b/sample/XFShapeViewSample/XFShapeViewSample.Droid/XFShapeViewSample.Droid.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />

--- a/sample/XFShapeViewSample/XFShapeViewSample/App.xaml.cs
+++ b/sample/XFShapeViewSample/XFShapeViewSample/App.xaml.cs
@@ -13,7 +13,7 @@ namespace XFShapeViewSample
         {
             InitializeComponent();
 
-            MainPage = new MainPage();
+            MainPage = new NavigationPage(new MainPage());
         }
 
         protected override void OnStart()

--- a/sample/XFShapeViewSample/XFShapeViewSample/BoxPage.xaml
+++ b/sample/XFShapeViewSample/XFShapeViewSample/BoxPage.xaml
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:sv="clr-namespace:XFShapeView;assembly=XFShapeView"
+             x:Class="XFShapeViewSample.BoxPage"
+             BackgroundColor="Silver">
+    <sv:ShapeView ShapeType="Box" Color="#FEFEF0" BorderColor="Red" BorderWidth="1" CornerRadius="10">
+        <sv:ShapeView.Padding>
+            <OnPlatform x:TypeArguments="Thickness" Android="20" iOS="20, 40, 20, 20" WinPhone="20"/>
+        </sv:ShapeView.Padding>
+        <StackLayout Orientation="Vertical" HorizontalOptions="FillAndExpand" VerticalOptions="Center" Spacing="20" Padding="20">
+            <Grid ColumnSpacing="-2" HeightRequest="60" HorizontalOptions="FillAndExpand">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="60"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="60"/>
+                </Grid.ColumnDefinitions>
+                <sv:ShapeView Grid.Column="0" ShapeType="Box" RadiusPosition="Left" CornerRadius="20" BorderWidth="2" Color="Silver" BorderColor="Teal">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnMinusTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="-" FontSize="32" Margin="10,0" VerticalOptions="Center" HorizontalOptions="CenterAndExpand"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="1" ShapeType="Box" BorderWidth="2" Color="Silver" BorderColor="Teal">
+                    <Label x:Name="Counter" Text="50" FontSize="24" Margin="10,0" VerticalOptions="Center" HorizontalOptions="CenterAndExpand"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="2" ShapeType="Box" RadiusPosition="Right" CornerRadius="20" BorderWidth="2" Color="Silver" BorderColor="Teal">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnPlusTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="+" FontSize="32" Margin="10,0" VerticalOptions="Center" HorizontalOptions="CenterAndExpand"/>
+                </sv:ShapeView>
+            </Grid>
+
+            <Grid ColumnSpacing="-2" RowSpacing="-2" HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="210" HeightRequest="280">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <sv:ShapeView Grid.Column="0" Grid.Row="0" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" RadiusPosition="TopLeft" CornerRadius="20" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="1" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="1" Grid.Row="0" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="2" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="2" Grid.Row="0" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" RadiusPosition="TopRight" CornerRadius="20" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="3" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="0" Grid.Row="1" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="4" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="1" Grid.Row="1" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="5" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="2" Grid.Row="1" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="6" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="0" Grid.Row="2" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="7" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="1" Grid.Row="2" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="8" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.Column="2" Grid.Row="2" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="9" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+                <sv:ShapeView Grid.ColumnSpan="3" Grid.Row="3" Color="Silver" BorderColor="Teal"
+                              ShapeType="Box" RadiusPosition="Bottom" CornerRadius="20" BorderWidth="2">
+                    <sv:ShapeView.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="OnNumberTapped"/>
+                    </sv:ShapeView.GestureRecognizers>
+                    <Label Text="0" FontSize="28" HorizontalOptions="Center" VerticalOptions="Center"/>
+                </sv:ShapeView>
+            </Grid>
+        </StackLayout>
+    </sv:ShapeView>
+
+</ContentPage>

--- a/sample/XFShapeViewSample/XFShapeViewSample/BoxPage.xaml.cs
+++ b/sample/XFShapeViewSample/XFShapeViewSample/BoxPage.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using XFShapeView;
+
+namespace XFShapeViewSample
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class BoxPage : ContentPage
+    {
+        public BoxPage()
+        {
+            InitializeComponent();
+        }
+
+        public void OnMinusTapped(object sender, EventArgs e)
+        {
+            var counter = (Convert.ToInt32(this.Counter.Text) - 1);
+            if (counter < 0) counter = 101 + counter;
+            this.Counter.Text = counter.ToString();
+        }
+
+        public void OnPlusTapped(object sender, EventArgs e)
+        {
+            var counter = (Convert.ToInt32(this.Counter.Text) + 1) % 101;
+            this.Counter.Text = counter.ToString();
+        }
+
+        public void OnNumberTapped(object sender, EventArgs e)
+        {
+            this.SetCounter(((Label)((ShapeView)sender).Content).Text);
+        }
+
+        private void SetCounter(string number)
+        {
+            var text = string.IsNullOrEmpty(this.Counter.Text) ? "0" : this.Counter.Text;
+            this.Counter.Text = Convert.ToInt32(text[this.Counter.Text.Length - 1] + number).ToString();
+        }
+    }
+}

--- a/sample/XFShapeViewSample/XFShapeViewSample/MainPage.xaml.cs
+++ b/sample/XFShapeViewSample/XFShapeViewSample/MainPage.xaml.cs
@@ -25,18 +25,18 @@ namespace XFShapeViewSample
             var box = new ShapeView
             {
                 ShapeType = ShapeType.Box,
-                HeightRequest = 75,
-                WidthRequest = 75,
+                HeightRequest = 80,
+                WidthRequest = 80,
                 Color = Color.Navy,
                 HorizontalOptions = LayoutOptions.Center,
                 VerticalOptions = LayoutOptions.Center,
-                CornerRadius = 5,
+                CornerRadius = 10,
                 BorderColor = Color.Red,
                 BorderWidth = 2f,
                 Content = new Label
                 {
                     Text = "Touch me!",
-                    FontSize = Device.GetNamedSize(NamedSize.Micro, typeof (Label)),
+                    FontSize = Device.GetNamedSize(NamedSize.Small, typeof (Label)),
                     TextColor = Color.White,
                     HorizontalOptions = LayoutOptions.Fill,
                     VerticalOptions = LayoutOptions.Fill,
@@ -51,7 +51,7 @@ namespace XFShapeViewSample
             var tap = new TapGestureRecognizer
             {
                 Command = new Command(() => {
-                    this.DisplayAlert("Touched", "This shape responds to touch!", "Ok");
+                    this.Navigation.PushAsync(new BoxPage());
                 })
             };
 

--- a/sample/XFShapeViewSample/XFShapeViewSample/XFShapeViewSample.csproj
+++ b/sample/XFShapeViewSample/XFShapeViewSample/XFShapeViewSample.csproj
@@ -38,6 +38,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="BoxPage.xaml.cs">
+      <DependentUpon>BoxPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
@@ -75,6 +78,12 @@
       <Project>{67F9D3A8-F71E-4428-913F-C37AE82CDB24}</Project>
       <Name>XFShapeView</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="BoxPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/src/XFShapeView.Droid/Box.cs
+++ b/src/XFShapeView.Droid/Box.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using Android.Graphics;
+
+namespace XFShapeView.Droid
+{
+    public class Box
+    {
+        private delegate void PathDrawFunction(Path p);
+        private List<PathDrawFunction> pathDrawSteps;
+
+        public Box(float left, float top, float width, float height, float cornerRadius, RadiusPosition radiusPosition)
+        {
+            this.pathDrawSteps = new List<PathDrawFunction>
+            {
+                (Path path) => path.MoveTo(left + (((radiusPosition & RadiusPosition.TopLeft) > 0)? cornerRadius : 0f), top),
+                (Path path) => path.LineTo(left + width - (((radiusPosition & RadiusPosition.TopRight) > 0)? cornerRadius : 0f), top)
+            };
+
+            if ((radiusPosition & RadiusPosition.TopRight) > 0)
+                this.pathDrawSteps.Add((Path path) => path.ArcTo(new RectF(left + width - cornerRadius, top, left + width, top + cornerRadius), -90f, 90f));
+
+            this.pathDrawSteps.Add((Path path) => path.LineTo(left + width, top + height - (((radiusPosition & RadiusPosition.BottomRight) > 0) ? cornerRadius : 0f)));
+
+            if ((radiusPosition & RadiusPosition.BottomRight) > 0)
+                this.pathDrawSteps.Add((Path path) => path.ArcTo(new RectF(left + width - cornerRadius, top + height - cornerRadius, left + width, top + height), 0f, 90f));
+
+            this.pathDrawSteps.Add((Path path) => path.LineTo(left + (((radiusPosition & RadiusPosition.BottomLeft) > 0) ? cornerRadius : 0f), top + height));
+
+            if ((radiusPosition & RadiusPosition.BottomLeft) > 0)
+                this.pathDrawSteps.Add((Path path) => path.ArcTo(new RectF(left, top + height - cornerRadius, left + cornerRadius, top + height), 90f, 90f));
+
+            this.pathDrawSteps.Add((Path path) => path.LineTo(left, top + (((radiusPosition & RadiusPosition.TopLeft) > 0) ? cornerRadius : 0f)));
+
+            if ((radiusPosition & RadiusPosition.TopLeft) > 0)
+                this.pathDrawSteps.Add((Path path) => path.ArcTo(new RectF(left, top, left + cornerRadius, top + cornerRadius), 180f, 90f));
+        }
+
+        public Path GetBoxPath()
+        {
+            var path = new Path();
+
+            foreach(PathDrawFunction drawStep in this.pathDrawSteps)
+            {
+                drawStep.Invoke(path);
+            }
+
+            path.Close();
+
+            return path;
+        }
+    }
+}

--- a/src/XFShapeView.Droid/Shape.cs
+++ b/src/XFShapeView.Droid/Shape.cs
@@ -82,7 +82,7 @@ namespace XFShapeView.Droid
             switch (this._shapeView.ShapeType)
             {
                 case ShapeType.Box:
-                    this.DrawBox(canvas, x, y, width, height, this._shapeView.CornerRadius, fillPaint, strokePaint);
+                    this.DrawBox(canvas, x, y, width, height, this._shapeView.CornerRadius, this._shapeView.RadiusPosition, fillPaint, strokePaint);
                     break;
                 case ShapeType.Circle:
                     this.DrawCircle(canvas, cx, cy, Math.Min(height, width)/2f, fillPaint, strokePaint);
@@ -139,17 +139,28 @@ namespace XFShapeView.Droid
 
         #region Basic shapes
 
-        protected virtual void DrawBox(Canvas canvas, float left, float top, float width, float height, float cornerRadius, Paint fillPaint, Paint strokePaint)
+        protected virtual void DrawBox(Canvas canvas, float left, float top, float width, float height, float cornerRadius, RadiusPosition radiusPosition, Paint fillPaint, Paint strokePaint)
         {
             var rect = new RectF(left, top, left + width, top + height);
-            if (cornerRadius > 0)
+
+            if (cornerRadius > 0 && radiusPosition != RadiusPosition.None)
             {
                 var cr = this.Resize(cornerRadius);
-                if (fillPaint != null)
-                    canvas.DrawRoundRect(rect, cr, cr, fillPaint);
 
-                if (strokePaint != null)
-                    canvas.DrawRoundRect(rect, cr, cr, strokePaint);
+                if (radiusPosition == RadiusPosition.All)
+                {
+                    if (fillPaint != null)
+                        canvas.DrawRoundRect(rect, cr, cr, fillPaint);
+
+                    if (strokePaint != null)
+                        canvas.DrawRoundRect(rect, cr, cr, strokePaint);
+                }
+                else
+                {
+                    var box = new Box(left, top, width, height, cr, radiusPosition);
+                    var path = box.GetBoxPath();
+                    this.DrawPath(canvas, path, fillPaint, strokePaint);
+                }
             }
             else
             {

--- a/src/XFShapeView.Droid/XFShapeView.Droid.csproj
+++ b/src/XFShapeView.Droid/XFShapeView.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -97,6 +97,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Box.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Shape.cs" />

--- a/src/XFShapeView.iOS/Box.cs
+++ b/src/XFShapeView.iOS/Box.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using CoreGraphics;
+
+namespace XFShapeView.iOS
+{
+    public class Box
+    {
+        private delegate void PathDrawFunction(CGPath p);
+        private List<PathDrawFunction> pathDrawSteps;
+
+        public Box(float left, float top, float width, float height, float cornerRadius, RadiusPosition radiusPosition)
+        {
+            this.pathDrawSteps = new List<PathDrawFunction>
+            {
+                (CGPath path) => path.MoveToPoint(left + (((radiusPosition & RadiusPosition.TopLeft) > 0)? cornerRadius : 0f), top),
+                (CGPath path) => path.AddLineToPoint(left + width - (((radiusPosition & RadiusPosition.TopRight) > 0)? cornerRadius : 0f), top)
+            };
+
+            if ((radiusPosition & RadiusPosition.TopRight) > 0)
+                this.pathDrawSteps.Add((CGPath path) => path.AddArcToPoint(left + width, top, left + width, top + cornerRadius, cornerRadius));
+
+            this.pathDrawSteps.Add((CGPath path) => path.AddLineToPoint(left + width, top + height - (((radiusPosition & RadiusPosition.BottomRight) > 0) ? cornerRadius : 0f)));
+
+            if ((radiusPosition & RadiusPosition.BottomRight) > 0)
+                this.pathDrawSteps.Add((CGPath path) => path.AddArcToPoint(left + width, top + height, left + width - cornerRadius, top + height, cornerRadius));
+
+            this.pathDrawSteps.Add((CGPath path) => path.AddLineToPoint(left + (((radiusPosition & RadiusPosition.BottomLeft) > 0) ? cornerRadius : 0f), top + height));
+
+            if ((radiusPosition & RadiusPosition.BottomLeft) > 0)
+                this.pathDrawSteps.Add((CGPath path) => path.AddArcToPoint(left, top + height, left, top + height - cornerRadius, cornerRadius));
+
+            this.pathDrawSteps.Add((CGPath path) => path.AddLineToPoint(left, top + (((radiusPosition & RadiusPosition.TopLeft) > 0) ? cornerRadius : 0f)));
+
+            if ((radiusPosition & RadiusPosition.TopLeft) > 0)
+                this.pathDrawSteps.Add((CGPath path) => path.AddArcToPoint(left, top, left + cornerRadius, top, cornerRadius));
+        }
+
+        public CGPath GetBoxPath()
+        {
+            var path = new CGPath();
+
+            foreach (PathDrawFunction drawStep in this.pathDrawSteps)
+            {
+                drawStep.Invoke(path);
+            }
+
+            path.CloseSubpath();
+
+            return path;
+        }
+    }
+}

--- a/src/XFShapeView.iOS/ShapeRenderer.cs
+++ b/src/XFShapeView.iOS/ShapeRenderer.cs
@@ -31,6 +31,7 @@ namespace XFShapeView.iOS
                 case nameof(this.Element.RadiusRatio):
                 case nameof(this.Element.NumberOfPoints):
                 case nameof(this.Element.CornerRadius):
+                case nameof(this.Element.RadiusPosition):
                 case nameof(this.Element.Progress):
                 case nameof(this.Element.Points):
                     this.SetNeedsDisplay();
@@ -91,7 +92,7 @@ namespace XFShapeView.iOS
             switch (this.Element.ShapeType)
             {
                 case ShapeType.Box:
-                    this.DrawBox(context, x, y, width, height, this.Element.CornerRadius, fill, stroke);
+                    this.DrawBox(context, x, y, width, height, this.Element.CornerRadius, this.Element.RadiusPosition, fill, stroke);
                     break;
                 case ShapeType.Circle:
                     this.DrawCircle(context, cx, cy, Math.Min(height, width) / 2f, fill, stroke);
@@ -162,13 +163,27 @@ namespace XFShapeView.iOS
 
         #region Basic shapes
 
-        protected virtual void DrawBox(CGContext context, float x, float y, float width, float height, float cornerRadius, bool fill, bool stroke)
+        protected virtual void DrawBox(CGContext context, float x, float y, float width, float height, float cornerRadius, RadiusPosition radiusPosition, bool fill, bool stroke)
         {
             var rect = new RectangleF(x, y, width, height);
-            if (cornerRadius > 0)
-                context.AddPath(UIBezierPath.FromRoundedRect(rect, cornerRadius).CGPath);
+
+            if (cornerRadius > 0 && radiusPosition != RadiusPosition.None)
+            {
+                if (radiusPosition == RadiusPosition.All)
+                {
+                    context.AddPath(UIBezierPath.FromRoundedRect(rect, cornerRadius).CGPath);
+                }
+                else
+                {
+                    var box = new Box(x, y, width, height, cornerRadius, radiusPosition);
+                    var path = box.GetBoxPath();
+                    context.AddPath(path);
+                }
+            }
             else
+            {
                 context.AddRect(rect);
+            }
 
             this.DrawPath(context, fill, stroke);
         }

--- a/src/XFShapeView.iOS/XFShapeView.iOS.csproj
+++ b/src/XFShapeView.iOS/XFShapeView.iOS.csproj
@@ -58,6 +58,7 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Box.cs" />
     <Compile Include="PointExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShapeRenderer.cs" />

--- a/src/XFShapeView/RadiusPosition.cs
+++ b/src/XFShapeView/RadiusPosition.cs
@@ -1,0 +1,73 @@
+﻿namespace XFShapeView
+{
+    /// <summary>
+    /// Define the corners of a box that have a radius
+    /// </summary>
+    public enum RadiusPosition
+    {
+        /// <summary>
+        /// No corner have a radius
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Only the top left corner has a radius
+        /// </summary>
+        TopLeft = 1,
+        /// <summary>
+        /// Only the top right corner has a radius
+        /// </summary>
+        TopRight = 2,
+        /// <summary>
+        /// Only the top corners (left and right) have a radius
+        /// </summary>
+        Top = 3,
+        /// <summary>
+        /// Only the bottom right corner has a radius
+        /// </summary>
+        BottomRight = 4,
+        /// <summary>
+        /// Only the top left and bottom right corners have a radius
+        /// </summary>
+        TopLeftAndBottomRight = 5,
+        /// <summary>
+        /// Only the right corners (top and bottom) have a radius
+        /// </summary>
+        Right = 6,
+        /// <summary>
+        /// Only the top left, top right and bottom right corners have a radius
+        /// </summary>
+        TopAndBottomRight = 7,
+        /// <summary>
+        /// Only the bottom left corner has a radius
+        /// </summary>
+        BottomLeft = 8,
+        /// <summary>
+        /// Only the left corners (top and bottom) have a radius
+        /// </summary>
+        Left = 9,
+        /// <summary>
+        /// Only the top right and bottom left corners have a radius
+        /// </summary>
+        TopRightAndBottomLeft = 10,
+        /// <summary>
+        /// Only the top left, top right and bottom left corners have a radius
+        /// </summary>
+        TopAndBottomLeft = 11,
+        /// <summary>
+        /// Only the bottom corners (left and right) have a radius
+        /// </summary>
+        Bottom = 12,
+        /// <summary>
+        /// Only the top left, bottom left and bottom right corners have a radius
+        /// </summary>
+        TopLeftAndBottom = 13,
+        /// <summary>
+        /// Only the top right, the bottom left and bottom right corners have a radius
+        /// </summary>
+        TopRightAndBottom = 14,
+        /// <summary>
+        /// All the corners have a radius
+        /// </summary>
+        All = 15
+    }
+}

--- a/src/XFShapeView/ShapeView.cs
+++ b/src/XFShapeView/ShapeView.cs
@@ -14,6 +14,7 @@ namespace XFShapeView
         public static readonly BindableProperty BorderColorProperty = BindableProperty.Create(nameof(BorderColor), typeof(Color), typeof(ShapeView), Color.Black);
         public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(BorderWidth), typeof(float), typeof(ShapeView), 0f);
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(ShapeView), 0f);
+        public static readonly BindableProperty RadiusPositionProperty = BindableProperty.Create(nameof(RadiusPosition), typeof(RadiusPosition), typeof(ShapeView), RadiusPosition.All);
         public static readonly BindableProperty ProgressProperty = BindableProperty.Create(nameof(Progress), typeof(float), typeof(ShapeView), 0f);
         public static readonly BindableProperty NumberOfPointsProperty = BindableProperty.Create(nameof(NumberOfPoints), typeof(int), typeof(ShapeView), 5);
         public static readonly BindableProperty ProgressBorderColorProperty = BindableProperty.Create(nameof(ProgressBorderColor), typeof(Color), typeof(ShapeView), Color.Black);
@@ -66,6 +67,15 @@ namespace XFShapeView
         {
             get { return (float)this.GetValue(CornerRadiusProperty); }
             set { this.SetValue(CornerRadiusProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the radius position - default value is RadiusPosition.All
+        /// </summary>
+        public RadiusPosition RadiusPosition
+        {
+            get { return (RadiusPosition)this.GetValue(RadiusPositionProperty); }
+            set { this.SetValue(RadiusPositionProperty, value); }
         }
 
         #region Star

--- a/src/XFShapeView/XFShapeView.csproj
+++ b/src/XFShapeView/XFShapeView.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RadiusPosition.cs" />
     <Compile Include="ShapeType.cs" />
     <Compile Include="ShapeView.cs" />
   </ItemGroup>


### PR DESCRIPTION
This makes it possible to choose, for a box, the corners that have a radius.
It's a practical functionality for the design of all kinds of buttons (see screenshot in attachment).
I'm sorry for the iOS version, I don't have the right equipment.
I haven't been able to test behavior under iOS. I'm not sure if it's free of bugs.
The sample has been updated with a new page for this feature.
![shapeview_screenshot](https://user-images.githubusercontent.com/32610622/31718538-96aa756e-b410-11e7-90b1-2e66ad0b21fd.png)
